### PR TITLE
[PLATFORM-1960] Add topics to repository

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,3 +12,9 @@ branches:
     protection:
       required_status_checks:
         strict: true
+
+repository:
+  # See https://github.com/apps/settings for all available settings.
+  name: react-ui-pairing-exercise
+  description: null
+  topics: "squad::Personal Savings, mission::Personal Savings, product::Transactional Bank, environment::Sandbox"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,20 +1,16 @@
 _extends: .github:.github/default-settings.yml
-
 repository:
   name: react-ui-pairing-exercise
-
 collaborators:
   - username: onb-githubuser
     permission: push
-
 branches:
   - name: main
     protection:
       required_status_checks:
         strict: true
-
 repository:
   # See https://github.com/apps/settings for all available settings.
   name: react-ui-pairing-exercise
   description: null
-  topics: "squad::Personal Savings, mission::Personal Savings, product::Transactional Bank, environment::Sandbox"
+  topics: squad-personal savings, mission-personal savings, product-transactional-bank, environment-sandbox

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,4 +13,4 @@ repository:
   # See https://github.com/apps/settings for all available settings.
   name: react-ui-pairing-exercise
   description: null
-  topics: squad-personal savings, mission-personal savings, product-transactional-bank, environment-sandbox
+  topics: squad-personal-savings, mission-personal savings, product-transactional-bank, environment-sandbox

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,4 +13,4 @@ repository:
   # See https://github.com/apps/settings for all available settings.
   name: react-ui-pairing-exercise
   description: null
-  topics: squad-personal-savings, mission-personal savings, product-transactional-bank, environment-sandbox
+  topics: squad-personal-savings, mission-personal-savings, product-transactional-bank, environment-sandbox


### PR DESCRIPTION
In order to easily group GitHub repositories together, we utilise topics to act as labels. We assign a squad to each repository to act as the main point of contact. Read more here: https://oaknorth-bank.atlassian.net/wiki/spaces/ENG/pages/287670416/GitHub+Topics